### PR TITLE
Lock down release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release
-
+permissions: {}
 on:
   push:
     branches:
@@ -10,6 +10,8 @@ jobs:
     name: Release
     if: ${{ github.repository_owner == 'delucis' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
+          persist-credentials: false
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,3 @@ jobs:
           title: '[ci] release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Removes NPM token (in favour of OIDC)
- Removes unnecessary permissions
- Doesn’t persist Git credentials when checking out the repo