### PR TITLE
Give `id-token` permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:


### PR DESCRIPTION
Something of a guess based on https://github.com/changesets/changesets/pull/1659

Follow-follow-follow-up to #15, #16, and #17.