### PR TITLE
Set `NPM_TOKEN` to empty string in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,4 @@ jobs:
           title: '[ci] release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ''


### PR DESCRIPTION
Trying a workaround as per https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868