### PR TITLE
Update npm in release workflow so it supports OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: 22
           cache: 'pnpm'
       - run: pnpm install
+      - name: Upgrade npm for trusted publishing
+        run: npm i -g npm@^11.5.2 # TODO: remove when setup-node action comes with npm version that contains OIDC setup by default
       - name: Create Release Pull Request
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
         with:
@@ -35,4 +37,4 @@ jobs:
           title: '[ci] release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ''
+          NPM_TOKEN: "" # See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868


### PR DESCRIPTION
Digging through a few people who have this working and it sounds like the npm version bundled with the `setup-node` action is not fully updated yet, and doesn’t include automatic OIDC support. This PR adds a step to the release workflow to force update npm.

References:
- https://github.com/svitejs/sfcsplit/blob/be6565f55308514b4ee895c8ed096bb221dc3d97/.github/workflows/release.yml#L47
- https://github.com/sapphi-red/vite-plugin-static-copy/blob/f4da2cf351642aa9d76ba92c9ec4f55b3d304783/.github/workflows/release.yaml#L24-L25