### PR TITLE
Remove redundant workflow step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - run: pnpm install
-      - name: Upgrade npm for trusted publishing
-        run: npm i -g npm@^11.5.2 # TODO: remove when setup-node action comes with npm version that contains OIDC setup by default
       - name: Create Release Pull Request
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
         with:


### PR DESCRIPTION
Explicitly updating npm used to be needed, but using Node 24 is now sufficient.