### PR TITLE
Fix builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"scripts": {
 		"build": "tsdown --dts --no-fixed-extension",
 		"prepublishOnly": "pnpm build",
+		"pretest": "pnpm build",
 		"test": "vitest",
 		"ci-version": "changeset version && pnpm install --no-frozen-lockfile",
 		"ci-publish": "changeset publish"

--- a/test/fontace.test.ts
+++ b/test/fontace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { fontace } from '../src';
+import { fontace } from '../dist';
 
 import interVariableWoff2String from '@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url&inline';
 import roboto400ItalicWoff2String from '@fontsource/roboto/files/roboto-latin-400-italic.woff2?url&inline';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
 		"moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
 		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
 		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-		"strict": true /* Enable all strict type-checking options. */
+		"strict": true /* Enable all strict type-checking options. */,
+		"isolatedDeclarations": true,
+		"declaration": true
 	},
 	"exclude": ["./dist/**/*"]
 }


### PR DESCRIPTION
- Builds were no longer working due to `typescript` not being available to `tsdown`
- Fixed by using isolated declarations, which the codebase was already compatible with, and doesn’t require `typescript`

Not sure **when** builds broke because in CI we were only running tests against `src/`. A build would only be run when trying to publish. To protect against that happening again in the future this PR also switches to running a build before tests and testing the `dist/` instead of source code.